### PR TITLE
`numpy.string_` -> `numpy.str_` for `numpy` v2

### DIFF
--- a/cmapPy/pandasGEXpress/write_gctx.py
+++ b/cmapPy/pandasGEXpress/write_gctx.py
@@ -165,7 +165,7 @@ def write_metadata(hdf5_out, dim, metadata_df, convert_back_to_neg_666, gzip_com
         logger.error("'dim' argument must be either 'row' or 'col'!")
 
     # write id field to expected node
-    hdf5_out.create_dataset(metadata_node_name + "/id", data=[numpy.sr_(str(x)) for x in metadata_df.index],
+    hdf5_out.create_dataset(metadata_node_name + "/id", data=[numpy.bytes_(str(x)) for x in metadata_df.index],
         compression=gzip_compression)
 
     metadata_fields = list(metadata_df.columns.copy())

--- a/cmapPy/pandasGEXpress/write_gctx.py
+++ b/cmapPy/pandasGEXpress/write_gctx.py
@@ -103,7 +103,7 @@ def write_version(hdf5_out):
 	Input:
 		- hdf5_out (h5py): hdf5 file to write to 
 	"""
-    hdf5_out.attrs[version_attr] = numpy.string_(version_number)
+    hdf5_out.attrs[version_attr] = numpy.str_(version_number)
 
 def calculate_elem_per_kb(max_chunk_kb, matrix_dtype):
     """
@@ -165,7 +165,7 @@ def write_metadata(hdf5_out, dim, metadata_df, convert_back_to_neg_666, gzip_com
         logger.error("'dim' argument must be either 'row' or 'col'!")
 
     # write id field to expected node
-    hdf5_out.create_dataset(metadata_node_name + "/id", data=[numpy.string_(str(x)) for x in metadata_df.index],
+    hdf5_out.create_dataset(metadata_node_name + "/id", data=[numpy.sr_(str(x)) for x in metadata_df.index],
         compression=gzip_compression)
 
     metadata_fields = list(metadata_df.columns.copy())

--- a/cmapPy/pandasGEXpress/write_gctx.py
+++ b/cmapPy/pandasGEXpress/write_gctx.py
@@ -177,7 +177,7 @@ def write_metadata(hdf5_out, dim, metadata_df, convert_back_to_neg_666, gzip_com
 
     # write metadata columns to their own arrays
     for field in [entry for entry in metadata_fields if entry != "ind"]:
-        if numpy.array(metadata_df.loc[:, field]).dtype.type in (numpy.bytes_, numpy.object_):
+        if numpy.array(metadata_df.loc[:, field]).dtype.type in (numpy.str_, numpy.object_):
             try:
                 array_write = numpy.array(metadata_df.loc[:, field]).astype('S')
             except UnicodeEncodeError:

--- a/cmapPy/pandasGEXpress/write_gctx.py
+++ b/cmapPy/pandasGEXpress/write_gctx.py
@@ -103,7 +103,7 @@ def write_version(hdf5_out):
 	Input:
 		- hdf5_out (h5py): hdf5 file to write to 
 	"""
-    hdf5_out.attrs[version_attr] = numpy.str_(version_number)
+    hdf5_out.attrs[version_attr] = numpy.bytes_(version_number)
 
 def calculate_elem_per_kb(max_chunk_kb, matrix_dtype):
     """
@@ -177,7 +177,7 @@ def write_metadata(hdf5_out, dim, metadata_df, convert_back_to_neg_666, gzip_com
 
     # write metadata columns to their own arrays
     for field in [entry for entry in metadata_fields if entry != "ind"]:
-        if numpy.array(metadata_df.loc[:, field]).dtype.type in (numpy.str_, numpy.object_):
+        if numpy.array(metadata_df.loc[:, field]).dtype.type in (numpy.bytes_, numpy.object_):
             try:
                 array_write = numpy.array(metadata_df.loc[:, field]).astype('S')
             except UnicodeEncodeError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.11.2
-pandas==0.20.3 
+numpy>=2.0
+pandas==2.2.2
 h5py==2.7.0
 requests==2.20.0
 


### PR DESCRIPTION
`numpy.string_` is an alias for `numpy.bytes_` in `numpy` versions < 2.0.
`numpy.string_` is removed from `numpy>=2.0`.

This PR bumps the version of `numpy` to `numpy>=2.0` and replaces `numpy.string_` by `numpy.bytes_` .